### PR TITLE
goxc / glide build POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+vendor
+build

--- a/.goxc.json
+++ b/.goxc.json
@@ -1,0 +1,4 @@
+{
+	"PackageVersion": "0.1.0",
+	"ConfigVersion": "0.9"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,26 @@
 # -*- Makefile -*-
+VERSION := $(shell cat .goxc.json | jq -r .PackageVersion)
 
-version=0.0.1
-deb_file=cqllock_${version}_amd64.deb
-
-build: test package
-
-test:
-	go test
-
-package:
-	goxc -bc="linux" -arch="amd64" -d build -pv="${version}"
+bootstrap:
+	goxc -wc
+	glide up
 
 clean:
-	rm -rf build
+	rm -rf ./build
+
+test:
+	go test -race -v .
+
+build: clean test
+	goxc -bc="linux,darwin" -arch="amd64" -d build -build-ldflags "-X main.version=${VERSION}" xc
+
+release: bump-patch build
+
+bump-patch:
+	goxc bump
+
+bump-minor:
+	goxc -dot=1 bump
+
+bump-major:
+	goxc -dot=0 bump

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,30 @@
+hash: 7d7841ec68b40fe4a05f635deb0c34830cc5ab54b4db42cc702e8a8048d3aa32
+updated: 2016-01-04T11:44:23.426530471-06:00
+imports:
+- name: github.com/alecthomas/template
+  version: 14fd436dd20c3cc65242a9f396b61bfc8a3926fc
+- name: github.com/alecthomas/units
+  version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
+- name: github.com/gocql/gocql
+  version: 57edf1e37c2a405b279cb656f8f0799ce3473b8e
+- name: github.com/golang/snappy
+  version: 723cc1e459b8eea2dea4583200fd60757d40097a
+- name: github.com/hailocab/go-hostpool
+  version: 50839ee41f32bfca8d03a183031aa634b2dc1c64
+- name: github.com/mitchellh/go-homedir
+  version: d682a8f0cf139663a984ff12528da460ca963de9
+- name: github.com/Sirupsen/logrus
+  version: 446d1c146faa8ed3f4218f056fcd165f6bcfda81
+- name: github.com/SmartThingsOSS/stcql
+  version: aafa5229681acf5bb3218cd0cfb6dbe8f267aff5
+- name: gopkg.in/airbrake/gobrake.v2
+  version: c9d51adc624b5cc4c1bf8de730a09af4878ffe2d
+- name: gopkg.in/alecthomas/kingpin.v2
+  version: 8852570bd3865e9c4d4cb7cf5001c4295b07cad5
+- name: gopkg.in/gemnasium/logrus-airbrake-hook.v2
+  version: 31e6fd4bd5a98d8ee7673d24bc54ec73c31810dd
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+- name: gopkg.in/yaml.v2
+  version: f7716cbe52baa25d2e9b0d0da546fcf909fc16b4
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,8 @@
+package: github.com/SmartThingsOSS/cqllock
+import:
+- package: github.com/Sirupsen/logrus
+- package: github.com/SmartThingsOSS/stcql
+- package: github.com/gocql/gocql
+- package: github.com/mitchellh/go-homedir
+- package: gopkg.in/alecthomas/kingpin.v2
+- package: gopkg.in/yaml.v2

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	holderFlag = kingpin.Flag("holder", "Name of the lock holder. Defaults to hostname.").Short('h').String()
 	unlock     = kingpin.Flag("unlock", "Unlock instead of lock.").Short('u').Default("false").Bool()
 	debug      = kingpin.Flag("debug", "Print debugging messages.").Default("false").Bool()
+	version    = "dev"
 )
 
 func defaultHolder() *string {
@@ -31,6 +32,7 @@ func defaultHolder() *string {
 }
 
 func main() {
+	kingpin.Version(version)
 	kingpin.Parse()
 	if *debug {
 		log.SetLevel(log.DebugLevel)


### PR DESCRIPTION
Here's my version of Charlie's PR #4, using:
- Make
- glide 0.8.2
- goxc 0.18.1

What I like about this is that it really has no extras, works with the native golang toolchain and supports both libs and binaries uniformly.

```
# setup
make bootstrap

# development
make test

# build locally
make build

# release
make release
```

There's also some convenience functions for bumping versions: `make bump[-minor|-major|-patch]

cc @acm1 @charliek
